### PR TITLE
feat(frontend): Implement drawer UI and speech recognition hook

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.11.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.7.1",
         "react-sketch-canvas": "^6.2.0"
       },
@@ -2046,6 +2047,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.7.1",
     "react-sketch-canvas": "^6.2.0"
   },

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -69,10 +69,14 @@ body {
 .whiteboard-area {
   display: flex;
   flex-direction: column;
+  grid-column: 2 / 3; 
+  grid-row: 1 / 2; 
   align-items: center;
   width: 100%; 
   max-width: 800px; 
   margin: 0 auto;
+  flex-grow: 1;
+  
 }
 
 .upload-section {
@@ -86,50 +90,233 @@ body {
   background-color: #fdfdfd;
 }
 
-/* App.css'in en altına ekle */
-
 .whiteboard-session {
-  display: flex;
-  gap: 1.5rem; /* Araç kutusu ile tahta arasına boşluk koyar */
+  display: grid; 
+  grid-template-columns: auto 1fr; 
+  grid-template-rows: auto 1fr; 
+  grid-row: 1 / 3;
+  gap: 1.5rem;
+  align-items: start;
 }
+
 
 .toolbar {
   display: flex;
-  flex-direction: column; /* Butonları alt alta diz */
-  gap: 0.75rem; /* Butonlar arasına boşluk koy */
-  padding: 1rem;
-  background-color: #edf2f7; /* Açık gri arka plan */
-  border-radius: 8px;
+  flex-direction: column;
+  gap: 0.5rem; 
+  padding: 0.75rem;
+  background-color: white; 
+  border-radius: 12px; 
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); 
+  border: 1px solid #e2e8f0;
 }
 
 .tool-button {
-  background-color: white;
-  border: 1px solid #cbd5e0;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
+  background-color: transparent; 
+  border: none;
+  padding: 0.75rem; 
+  border-radius: 8px;
   cursor: pointer;
-  font-weight: 500;
+  color: #4a5568; 
   transition: background-color 0.2s, color 0.2s;
 }
 
 .tool-button:hover {
-  background-color: #e2e8f0;
+  background-color: #f7fafc; 
+  color: #2d3748; 
 }
 
 .clear-button {
-  margin-top: auto; /* Bu butonu en alta iter */
-  background-color: #fed7d7; /* Kırmızımsı */
-  color: #c53030;
+  margin-top: 1rem; 
+  color: #e53e3e; 
 }
 
 .clear-button:hover {
-  background-color: #fbb6b6;
+  background-color: #fff5f5; 
+  color: #c53030;
 }
 
-/* .whiteboard-area'yı güncelleyelim */
-.whiteboard-area {
-  flex-grow: 1; /* Mevcut alanda yayılmasını sağlar */
+.tool-section {
+  padding: 0.5rem 0;
+  border-top: 1px solid #e2e8f0; 
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
 }
+
+.color-picker-box {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%; 
+  border: 2px solid white;
+  box-shadow: 0 0 0 1px #cbd5e0;
+  cursor: pointer;
+  transition: transform 0.1s;
+}
+
+.color-picker-box:hover {
+  transform: scale(1.1);
+}
+
+.stroke-slider {
+  width: 80%;
+  cursor: pointer;
+}
+
+
+.popover-container {
+  position: relative; 
+  display: inline-block;
+}
+
+.popover-menu {
+  position: absolute;
+  left: 100%; 
+  top: 0;
+  margin-left: 10px; 
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid #e2e8f0;
+  padding: 0.75rem;
+  width: 150px; 
+  z-index: 10; 
+}
+
+.tool-section.vertical {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.tool-section.vertical label {
+  font-size: 0.875rem;
+  color: #718096;
+  font-weight: 500;
+}
+
+.color-palette {
+  display: flex;
+  gap: 0.5rem;
+}
+
+
+.session-container {
+  position: relative; 
+  width: 100%;
+}
+
+.main-content {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start; 
+  transition: margin-left 0.3s ease-in-out; 
+}
+
+.chat-drawer {
+  position: fixed; 
+  left: -400px; 
+  top: 0;
+  width: 350px;
+  height: 100%;
+  background-color: #f8fafc;
+  box-shadow: 4px 0 15px rgba(0,0,0,0.1);
+  z-index: 20; 
+  transition: left 0.3s ease-in-out; 
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-drawer.open {
+  left: 0; 
+}
+
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 0.75rem;
+}
+
+.drawer-header h3 { 
+  margin: 0; 
+  color: #4a5568;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #a0aec0;
+  padding: 0 0.5rem;
+}
+
+.close-button:hover {
+  color: #4a5568;
+}
+
+.mic-button-toolbar {
+  color: #d32f2f; 
+}
+
+.mic-button-toolbar:hover {
+  background-color: #fff5f5;
+  color: #c53030;
+}
+
+.drawer-content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  overflow: hidden; 
+}
+
+.drawer-content .transcript-box {
+    flex-grow: 1; 
+    overflow-y: auto; /* İÇERİK SIĞMAZSA KAYDIRMA ÇUBUĞU ÇIKAR */
+    background-color: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.drawer-content .speech-controls {
+    display: flex;
+    justify-content: center;
+    padding-top: 1rem;
+}
+
+.drawer-content .mic-button {
+    background-color: #d32f2f;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    font-size: 14px;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s, transform 0.2s;
+}
+
+.drawer-content .mic-button:hover {
+    background-color: #c62828;
+    transform: scale(1.05);
+}
+
+.chat-drawer.open + .main-content {
+  margin-left: 350px; 
+}
+
 
 
 

--- a/frontend/src/components/ChatDrawer.jsx
+++ b/frontend/src/components/ChatDrawer.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+function ChatDrawer({ isOpen, onClose, transcript  }) {
+  return (
+    <div className={`chat-drawer ${isOpen ? 'open' : ''}`}>
+      <div className="drawer-header">
+        <h3>Sohbet Akışı</h3>
+        <button onClick={onClose} className="close-button">×</button>
+      </div>
+      <div className="drawer-content">
+        <div className="transcript-box">
+          <p><strong>Öğrenci:</strong> {transcript}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ChatDrawer;

--- a/frontend/src/components/ToolbarPopover.jsx
+++ b/frontend/src/components/ToolbarPopover.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+function ToolbarPopover({ icon, children }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const popoverRef = useRef(null);
+
+  // Dışarıya tıklandığında menüyü kapatmak için
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (popoverRef.current && !popoverRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [popoverRef]);
+
+  return (
+    <div className="popover-container" ref={popoverRef}>
+      <button onClick={() => setIsOpen(!isOpen)} className="tool-button">
+        {icon}
+      </button>
+      {isOpen && (
+        <div className="popover-menu">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ToolbarPopover;

--- a/frontend/src/components/Whiteboard.jsx
+++ b/frontend/src/components/Whiteboard.jsx
@@ -1,36 +1,33 @@
-// frontend/src/components/Whiteboard.jsx (SON VE KESİN HALİ)
 import React, { forwardRef } from 'react';
 import { ReactSketchCanvas } from 'react-sketch-canvas';
 
-// Ana kapsayıcının stili. Bu, hem resmi hem de tuvali içerecek.
 const containerStyle = {
-  position: 'relative', // İçindeki elemanları konumlandırmak için zorunlu
+  position: 'relative', 
   width: '100%',
   border: '2px dashed #a0aec0',
   borderRadius: '0.5rem',
-  overflow: 'hidden', // Taşan kısımları gizle
+  overflow: 'hidden', 
 };
 
-// Arka plan resminin stili
+
 const backgroundImageStyle = {
-  position: 'absolute', // Tuvalin tam arkasında duracak
+  position: 'absolute', 
   top: 0,
   left: 0,
   width: '100%',
   height: '100%',
-  objectFit: 'contain',         // İSTEK: Boyut oranını koru
-  objectPosition: 'top left',     // İSTEK: Sol üste hizala
-  opacity: 0.6,                   // İSTEK: Saydam yap
-  pointerEvents: 'none',          // Tıklamaları engellemesin
+  objectFit: 'contain',         
+  objectPosition: 'top left',     
+  opacity: 0.6,                   
+  pointerEvents: 'none',         
 };
 
 const Whiteboard = forwardRef(
-  ({ width, height, backgroundImage }, ref) => {
+  ({ width, height, backgroundImage, strokeColor, strokeWidth }, ref) => {
     return (
-      // Ana kapsayıcı div
+      
       <div style={{ ...containerStyle, width, height }}>
         
-        {/* Katman 1: Arka Plan Resmi (Bizim Kontrolümüzde) */}
         {backgroundImage && (
           <img 
             src={backgroundImage} 
@@ -39,16 +36,13 @@ const Whiteboard = forwardRef(
           />
         )}
 
-        {/* Katman 2: Çizim Tuvali (Tamamen Şeffaf) */}
         <ReactSketchCanvas
           ref={ref}
-          // Tuvalin kendisi şeffaf olacak ve çerçevesi olmayacak
-          // Çerçeveyi artık dıştaki div sağlıyor
           style={{ background: 'transparent' }}
           width={width}
           height={height}
-          strokeWidth={4}
-          strokeColor="black"
+          strokeWidth={strokeWidth}
+          strokeColor={strokeColor} 
         />
       </div>
     );

--- a/frontend/src/hooks/useSpeechRecognition.js
+++ b/frontend/src/hooks/useSpeechRecognition.js
@@ -1,0 +1,84 @@
+import { useState, useEffect, useRef } from 'react';
+
+const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+let recognition; 
+
+if (SpeechRecognition) {
+  recognition = new SpeechRecognition();
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.lang = 'tr-TR';
+}
+
+export const useSpeechRecognition = () => {
+  const [isListening, setIsListening] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  
+  const listeningRef = useRef(false);
+
+  useEffect(() => {
+   
+    if (!SpeechRecognition) {
+      return;
+    }
+
+    recognition.onstart = () => {
+      console.log('Ses tanıma BAŞLADI.');
+      listeningRef.current = true;
+      setIsListening(true);
+    };
+
+    recognition.onend = () => {
+      console.log('Ses tanıma DURDU.');
+     
+      if (listeningRef.current) {
+       
+        console.log('Beklenmedik durma, yeniden başlatılıyor...');
+        recognition.start();
+      } else {
+        
+        setIsListening(false);
+      }
+    };
+
+    recognition.onresult = (event) => {
+      let finalTranscript = '';
+      for (let i = event.resultIndex; i < event.results.length; ++i) {
+        if (event.results[i].isFinal) {
+          finalTranscript += event.results[i][0].transcript + ' ';
+        }
+      }
+      if (finalTranscript) {
+         setTranscript(prev => prev + finalTranscript);
+      }
+    };
+
+    recognition.onerror = (event) => {
+      console.error('Ses tanıma hatası:', event.error);
+    };
+
+    return () => {
+      listeningRef.current = false;
+      recognition.stop();
+    };
+  }, []); 
+
+  const toggleListening = () => {
+    if (!SpeechRecognition) {
+      alert("Üzgünüz, tarayıcınız ses tanımayı desteklemiyor.");
+      return;
+    }
+
+    if (isListening) {
+      console.log('Kullanıcı durdurmak istedi.');
+      listeningRef.current = false; 
+      recognition.stop();
+    } else {
+      console.log('Kullanıcı başlatmak istedi.');
+      setTranscript(''); 
+      recognition.start();
+    }
+  };
+
+  return { isListening, transcript, toggleListening, hasSpeechRecognitionSupport: !!SpeechRecognition };
+};

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,83 +1,133 @@
 import React, { useState, useRef } from 'react';
 
+import { 
+  FaPencilAlt, 
+  FaEraser, 
+  FaUndo, 
+  FaRedo, 
+  FaTrash, 
+  FaCommentDots, 
+  FaMicrophone, 
+  FaStop 
+} from "react-icons/fa";
+
 import ImageUploader from '../components/ImageUploader'; 
 import Whiteboard from '../components/Whiteboard';
+import ToolbarPopover from '../components/ToolbarPopover';
+import ChatDrawer from '../components/ChatDrawer';
+
+import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 
 function ChatPage() {
-
+  
   const [originalQuestionImage, setOriginalQuestionImage] = useState(null);
   const [isSessionStarted, setIsSessionStarted] = useState(false);
-
+  const [strokeColor, setStrokeColor] = useState('black'); 
+  const [strokeWidth, setStrokeWidth] = useState(4);
   const canvasRef = useRef(null);
+  const [isChatOpen, setIsChatOpen] = useState(false);
   
+  const { isListening, transcript, toggleListening } = useSpeechRecognition();
+
   const handleQuestionUpload = (file) => {
- 
-    console.log("Yüklenen soru dosyası:", file);
-    
-    // Geçici: Dosyanın bir URL'ini oluşturalım ki Whiteboard'da gösterelim
     const tempImageUrl = URL.createObjectURL(file);
     setOriginalQuestionImage(tempImageUrl);
     setIsSessionStarted(true);
   };
 
-  const eraseMode = () => {
-    // canvasRef üzerinden tuvalin silgi moduna geçmesini sağlıyoruz.
-    canvasRef.current?.eraseMode(true); 
-  };
+  const eraseMode = () => { canvasRef.current?.eraseMode(true); };
+  const drawMode = () => { canvasRef.current?.eraseMode(false); };
+  const undo = () => { canvasRef.current?.undo(); };
+  const redo = () => { canvasRef.current?.redo(); };
+  const clearAll = () => { canvasRef.current?.clearCanvas(); };
 
-  const drawMode = () => {
-    // Tuvalin çizim moduna geri dönmesini sağlıyoruz.
+  const changeColor = (color) => {
+    setStrokeColor(color);
     canvasRef.current?.eraseMode(false);
+    canvasRef.current?.setState({ strokeColor: color });
   };
 
-  const undo = () => {
-    // Son yapılan işlemi geri al
-    canvasRef.current?.undo();
-  };
-
-  const redo = () => {
-    // Geri alınan işlemi ileri al
-    canvasRef.current?.redo();
-  };
-  
-  const clearAll = () => {
-    // Tüm çizimleri temizle
-    canvasRef.current?.clearCanvas();
+  const changeStrokeWidth = (width) => {
+    setStrokeWidth(width);
+    canvasRef.current?.setState({ strokeWidth: width });
   };
 
   return (
     <div className="chat-container">
       <h2 className="chat-title">Sokratik Öğrenme Alanı</h2>
 
-      {/* Eğer oturum henüz başlamadıysa, soru yükleme ekranını göster */}
       {!isSessionStarted ? (
         <div className="upload-section">
           <p className="instructions">Lütfen çözmek istediğin sorunun fotoğrafını yükle.</p>
           <ImageUploader onImageSelect={handleQuestionUpload} />
         </div>
       ) : (
-        
-        <div className="whiteboard-session">
-          <div className="toolbar">
-            {/* YENİ ARAÇ KUTUSU BUTONLARI */}
-            <button onClick={drawMode} className="tool-button">Kalem</button>
-            <button onClick={eraseMode} className="tool-button">Silgi</button>
-            <button onClick={undo} className="tool-button">Geri Al</button>
-            <button onClick={redo} className="tool-button">İleri Al</button>
-            <button onClick={clearAll} className="tool-button clear-button">Tümünü Temizle</button>
-          </div>
-          <div className="whiteboard-area">
-            <Whiteboard 
-              // "Uzaktan kumandamızı" Whiteboard'a prop olarak yolluyoruz.
-              ref={canvasRef} 
-              width="100%" 
-              height="500px" 
-              backgroundImage={originalQuestionImage}
-            />
+        <div className="session-container">
+          
+          <ChatDrawer 
+            isOpen={isChatOpen} 
+            onClose={() => setIsChatOpen(false)} 
+            transcript={transcript} 
+          />
+
+          <div className="main-content">
+            <div className="toolbar">
+              <ToolbarPopover icon={<FaPencilAlt size={20} />}>
+                <div className="tool-section vertical">
+                  <label>Renk</label>
+                  <div className="color-palette">
+                    <div className="color-picker-box" style={{ backgroundColor: 'black' }} onClick={() => changeColor('black')} />
+                    <div className="color-picker-box" style={{ backgroundColor: '#e53e3e' }} onClick={() => changeColor('#e53e3e')} />
+                    <div className="color-picker-box" style={{ backgroundColor: '#3182ce' }} onClick={() => changeColor('#3182ce')} />
+                  </div>
+                </div>
+                 <div className="tool-section vertical">
+                   <label>Kalınlık</label>
+                   <input 
+                     type="range" 
+                     min="1" 
+                     max="20" 
+                     value={strokeWidth} 
+                     onChange={(e) => changeStrokeWidth(e.target.value)}
+                     className="stroke-slider"
+                   />
+                 </div>
+              </ToolbarPopover>
+
+              <button onClick={eraseMode} className="tool-button" title="Silgi">
+                <FaEraser size={20} />
+              </button>
+              <button onClick={undo} className="tool-button" title="Geri Al">
+                <FaUndo size={20} />
+              </button>
+              <button onClick={redo} className="tool-button" title="İleri Al">
+                <FaRedo size={20} />
+              </button>
+              <button onClick={clearAll} className="tool-button clear-button" title="Tümünü Temizle">
+                <FaTrash size={20} />
+              </button>
+
+              <button onClick={() => setIsChatOpen(true)} className="tool-button" title="Sohbeti Göster">
+                <FaCommentDots size={20} />
+              </button>
+
+              <button onClick={toggleListening} className="tool-button mic-button-toolbar" title={isListening ? 'Dinlemeyi Durdur' : 'Konuşmaya Başla'}>
+                {isListening ? <FaStop size={20} /> : <FaMicrophone size={20} />}
+              </button>
+            </div>
+
+            <div className="whiteboard-area">
+              <Whiteboard 
+                ref={canvasRef} 
+                width="100%" 
+                height="500px" 
+                backgroundImage={originalQuestionImage}
+                strokeColor={strokeColor}
+                strokeWidth={strokeWidth}
+              />
+            </div>
           </div>
         </div>
-
-
       )}
     </div>
   );


### PR DESCRIPTION
Bu PR, kullanıcıların sesli komutlarla etkileşime geçmesini sağlayan temel altyapıyı kurar ve arayüzü modern "çekmeceli" bir yapıya kavuşturur.

**Yapılanlar:**
- Kullanıcının konuşmasını metne çevirmek için `useSpeechRecognition` adında özel bir React hook'u oluşturuldu.
- `SpeechControl` bileşeni kaldırılarak, sesle ilgili mantık ve durum yönetimi doğrudan `ChatPage`'e taşındı.
- Sohbet akışını göstermek için, sol taraftan açılan bir `ChatDrawer` (çekmece) bileşeni eklendi.
- Ana araç kutusuna (toolbar), çekmeceyi açmak için bir sohbet ikonu ve ses tanımayı başlatıp durdurmak için bir mikrofon ikonu eklendi.

Bu değişiklikler aşağıdaki görevleri tamamlar:
Closes #21
Closes #25